### PR TITLE
Clear stale ban state when nodes are unblocked

### DIFF
--- a/nuke_nodes.py
+++ b/nuke_nodes.py
@@ -8,6 +8,7 @@ import sys
 import os
 import logging
 import json
+import random
 
 # Set up logging
 LOG_FILE = '/var/log/asterisk/nuke_nodes.log'
@@ -27,6 +28,8 @@ DEFAULT_WHITELIST_PATHS = [
 CONNECTION_DISCONNECT_THRESHOLD = 5
 CONNECTION_BAN_THRESHOLD = 6
 CONNECTION_ATTEMPT_RESET_SECONDS = 900  # Reset attempt counter after 15 minutes of inactivity
+DEFAULT_NODE_FETCH_DELAY_SECONDS = 0.40
+DEFAULT_NODE_FETCH_JITTER_SECONDS = 0.20
 
 def log_message(message):
     """Logs a message to the log file and console."""
@@ -126,6 +129,18 @@ def normalize_loop_interval(requested_interval):
         )
         return 10
     return requested_interval
+
+
+def pace_api_request(last_request_time, min_delay_seconds, jitter_seconds):
+    """Sleep as needed so node-level stats requests are spread out over time."""
+    now = time.time()
+    elapsed = now - last_request_time
+    jitter = random.uniform(0, max(0.0, jitter_seconds))
+    wait_for = max(0.0, min_delay_seconds + jitter - elapsed)
+    if wait_for > 0:
+        time.sleep(wait_for)
+        now = time.time()
+    return now
 
 
 def handle_connection_attempt(node_id, connection_state, initial_node_id, timestamp):
@@ -356,10 +371,34 @@ def main():
     parser.add_argument('--area_restrictions', type=str, help='Path to the area restrictions file')
     parser.add_argument('--whitelist', type=str, help='Path to the whitelist file')
     parser.add_argument('--run-once', action='store_true', help='Process a single iteration and exit.')
+    parser.add_argument(
+        '--node-fetch-delay',
+        type=float,
+        default=DEFAULT_NODE_FETCH_DELAY_SECONDS,
+        help='Minimum seconds between per-node stats API calls (default: {}).'.format(
+            DEFAULT_NODE_FETCH_DELAY_SECONDS
+        ),
+    )
+    parser.add_argument(
+        '--node-fetch-jitter',
+        type=float,
+        default=DEFAULT_NODE_FETCH_JITTER_SECONDS,
+        help='Additional random delay added to per-node API pacing (default: {}).'.format(
+            DEFAULT_NODE_FETCH_JITTER_SECONDS
+        ),
+    )
     args = parser.parse_args()
 
     if args.run_once and args.loop is not None:
         print("Error: --loop cannot be used with --run-once.")
+        sys.exit(1)
+
+    if args.node_fetch_delay < 0:
+        print("Error: --node-fetch-delay must be >= 0.")
+        sys.exit(1)
+
+    if args.node_fetch_jitter < 0:
+        print("Error: --node-fetch-jitter must be >= 0.")
         sys.exit(1)
 
     if args.run_once:
@@ -376,6 +415,7 @@ def main():
     initial_url = STATS_URL + args.initial_node_id
 
     connection_state = load_state()
+    last_node_fetch_time = 0.0
     for node_id in list(connection_state.keys()):
         if is_whitelisted(node_id):
             connection_state.pop(node_id, None)
@@ -415,6 +455,11 @@ def main():
                     continue
 
                 node_url = "https://stats.allstarlink.org/api/stats/" + str(node_id)
+                last_node_fetch_time = pace_api_request(
+                    last_node_fetch_time,
+                    args.node_fetch_delay,
+                    args.node_fetch_jitter,
+                )
                 node_data = fetch_data(node_url, compact_not_found=True)
 
                 if not node_data:

--- a/nuke_nodes.py
+++ b/nuke_nodes.py
@@ -191,6 +191,7 @@ def handle_connection_attempt(node_id, connection_state, initial_node_id, timest
     node_state['is_connected'] = True
     node_state['last_connected_at'] = timestamp
     attempts = node_state['connection_attempts']
+    log_message("Node {} connected. Tracking reconnect behavior for this session.".format(node_id))
     log_message("Node {} connection attempt count: {}".format(node_id, attempts))
 
     if attempts >= CONNECTION_BAN_THRESHOLD:
@@ -443,7 +444,6 @@ def main():
             update_disconnection_status(links, connection_state, observation_time)
 
             for node_id in links:
-                log_message("Processing node ID: {}".format(node_id))
                 node_id_str = str(node_id)
 
                 if is_whitelisted(node_id_str):

--- a/nuke_nodes.py
+++ b/nuke_nodes.py
@@ -136,8 +136,16 @@ def handle_connection_attempt(node_id, connection_state, initial_node_id, timest
     node_state['last_seen_at'] = timestamp
 
     if node_state.get('banned'):
-        log_message("Node {} is already banned due to excessive reconnects.".format(node_id))
-        return True
+        if not is_node_blocked(node_id):
+            log_message(
+                "Node {} was previously banned but is no longer blocked. Clearing ban state.".format(node_id)
+            )
+            node_state['banned'] = False
+            node_state['connection_attempts'] = 0
+            node_state['last_disconnected_at'] = None
+        else:
+            log_message("Node {} is already banned due to excessive reconnects.".format(node_id))
+            return True
 
     if node_state.get('is_connected'):
         return False
@@ -216,6 +224,35 @@ def update_blocked_node(node_id, comment=""):
         log_message("Blocked node {} with comment: {}".format(node_id, sanitized_comment))
     except subprocess.CalledProcessError as e:
         log_message("Failed to block node {}: {}".format(node_id, e))
+
+
+def is_node_blocked(node_id):
+    """Check if the node is currently blocked in the Asterisk database."""
+    if is_whitelisted(node_id):
+        return False
+    command = "{} {} -rx \"database get {} {}\"".format(SUDO, ASTERISK, DB_FAMILY, node_id)
+    try:
+        result = subprocess.run(
+            command,
+            shell=True,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except Exception as error:
+        log_message("Failed to check block status for node {}: {}".format(node_id, error))
+        return True
+
+    output = (result.stdout or "") + (result.stderr or "")
+    if "Database entry not found" in output:
+        return False
+    if "Value:" in output:
+        return True
+
+    log_message("Unexpected block status response for node {}: {}".format(node_id, output.strip()))
+    return False
+
 
 def disconnect_node(node_id, initial_node_id, reason=""):
     """Disconnect a node using Asterisk rpt command."""

--- a/nuke_nodes.py
+++ b/nuke_nodes.py
@@ -278,8 +278,8 @@ def disconnect_node(node_id, initial_node_id, reason=""):
     except subprocess.CalledProcessError as e:
         log_message("Failed to disconnect node {} from {}: {}".format(node_id, initial_node_id, e))
 
-def fetch_data(url, max_retries=10, backoff_factor=2):
-    """Fetches data from the given URL with retry logic for handling rate limiting."""
+def fetch_data(url, max_retries=10, backoff_factor=2, compact_not_found=False):
+    """Fetch data from URL with retries for rate limiting and optional compact 404 logging."""
     retries = 0
     while retries < max_retries:
         try:
@@ -296,6 +296,12 @@ def fetch_data(url, max_retries=10, backoff_factor=2):
                 log_message("429 Too Many Requests. Retrying in {} seconds... (Retry-After: {})".format(wait_time, retry_after))
                 time.sleep(wait_time)
                 retries += 1
+            elif response.status_code == 404 and compact_not_found:
+                node_id = url.rsplit('/', 1)[-1]
+                log_message(
+                    "Node {} not found on stats API (likely private/unlisted). Skipping node.".format(node_id)
+                )
+                return None
             else:
                 log_message("Failed to fetch data. Status code: {}. URL: {}. Response headers: {}".format(
                     response.status_code, url, response.headers
@@ -409,7 +415,7 @@ def main():
                     continue
 
                 node_url = "https://stats.allstarlink.org/api/stats/" + str(node_id)
-                node_data = fetch_data(node_url)
+                node_data = fetch_data(node_url, compact_not_found=True)
 
                 if not node_data:
                     log_message("No data available for node {}. Skipping to next node.".format(node_id))

--- a/nuke_nodes.py
+++ b/nuke_nodes.py
@@ -491,11 +491,9 @@ def main():
 
                 # Check stats_enabled field
                 stats_enabled = node_data.get("stats_enabled", True)
-                log_message("Node {} stats_enabled value: {}".format(node_id, stats_enabled))
 
                 # Detect crosslinking
                 current_links = node_data.get('stats', {}).get('data', {}).get('links', [])
-                log_message("Node {} connected links: {}".format(node_id, current_links))
 
                 # Explicitly check if the node is only connected to the initial node
                 if current_links == [args.initial_node_id]:
@@ -518,7 +516,8 @@ def main():
                     continue
 
                 if stats_enabled is True:
-                    log_message("Node {} has stats explicitly enabled. It will remain connected.".format(node_id))
+                    if set_node_event(connection_state, node_id_str, 'stats_enabled_true'):
+                        log_message("Node {} has stats explicitly enabled. It will remain connected.".format(node_id))
                     continue
 
                 # Treat stats_enabled=None as disabled if stats is missing

--- a/nuke_nodes.py
+++ b/nuke_nodes.py
@@ -131,6 +131,15 @@ def normalize_loop_interval(requested_interval):
     return requested_interval
 
 
+
+def set_node_event(connection_state, node_id, event_name):
+    """Record node event state and return True when the event changed."""
+    node_key = str(node_id)
+    node_state = connection_state.setdefault(node_key, {})
+    previous_event = node_state.get('last_logged_event')
+    node_state['last_logged_event'] = event_name
+    return previous_event != event_name
+
 def pace_api_request(last_request_time, min_delay_seconds, jitter_seconds):
     """Sleep as needed so node-level stats requests are spread out over time."""
     now = time.time()
@@ -157,6 +166,7 @@ def handle_connection_attempt(node_id, connection_state, initial_node_id, timest
         'last_connected_at': None,
         'last_disconnected_at': None,
         'last_seen_at': None,
+        'last_logged_event': None,
     })
 
     node_state['last_seen_at'] = timestamp
@@ -170,7 +180,8 @@ def handle_connection_attempt(node_id, connection_state, initial_node_id, timest
             node_state['connection_attempts'] = 0
             node_state['last_disconnected_at'] = None
         else:
-            log_message("Node {} is already banned due to excessive reconnects.".format(node_id))
+            if set_node_event(connection_state, node_id, 'already_banned'):
+                log_message("Node {} is already banned due to excessive reconnects.".format(node_id))
             return True
 
     if node_state.get('is_connected'):
@@ -191,7 +202,8 @@ def handle_connection_attempt(node_id, connection_state, initial_node_id, timest
     node_state['is_connected'] = True
     node_state['last_connected_at'] = timestamp
     attempts = node_state['connection_attempts']
-    log_message("Node {} connected. Tracking reconnect behavior for this session.".format(node_id))
+    if set_node_event(connection_state, node_id, 'connected'):
+        log_message("Node {} connected. Tracking reconnect behavior for this session.".format(node_id))
     log_message("Node {} connection attempt count: {}".format(node_id, attempts))
 
     if attempts >= CONNECTION_BAN_THRESHOLD:
@@ -313,10 +325,6 @@ def fetch_data(url, max_retries=10, backoff_factor=2, compact_not_found=False):
                 time.sleep(wait_time)
                 retries += 1
             elif response.status_code == 404 and compact_not_found:
-                node_id = url.rsplit('/', 1)[-1]
-                log_message(
-                    "Node {} not found on stats API (likely private/unlisted). Skipping node.".format(node_id)
-                )
                 return None
             else:
                 log_message("Failed to fetch data. Status code: {}. URL: {}. Response headers: {}".format(
@@ -463,8 +471,11 @@ def main():
                 node_data = fetch_data(node_url, compact_not_found=True)
 
                 if not node_data:
-                    log_message("No data available for node {}. Skipping to next node.".format(node_id))
+                    if set_node_event(connection_state, node_id_str, 'no_data'):
+                        log_message("No data available for node {}. Skipping to next node.".format(node_id))
                     continue
+
+                set_node_event(connection_state, node_id_str, 'data_available')
 
                 # Check if stats field is None
                 stats = node_data.get("stats", None)

--- a/nuke_nodes.py
+++ b/nuke_nodes.py
@@ -13,6 +13,8 @@ import random
 # Set up logging
 LOG_FILE = '/var/log/asterisk/nuke_nodes.log'
 logging.basicConfig(filename=LOG_FILE, level=logging.DEBUG, format='%(asctime)s - %(message)s')
+logging.getLogger("urllib3").setLevel(logging.WARNING)
+logging.getLogger("requests").setLevel(logging.WARNING)
 
 STATE_FILE = '/var/log/asterisk/nuke_nodes_state.json'
 
@@ -313,7 +315,6 @@ def fetch_data(url, max_retries=10, backoff_factor=2, compact_not_found=False):
         try:
             response = requests.get(url)
             if response.status_code == 200:
-                log_message("Successfully fetched data from URL: {}".format(url))
                 return response.json()
             elif response.status_code == 429:
                 retry_after = response.headers.get("Retry-After")
@@ -425,6 +426,7 @@ def main():
 
     connection_state = load_state()
     last_node_fetch_time = 0.0
+    last_initial_links_signature = None
     for node_id in list(connection_state.keys()):
         if is_whitelisted(node_id):
             connection_state.pop(node_id, None)
@@ -447,7 +449,10 @@ def main():
 
             links = initial_data.get('stats', {}).get('data', {}).get('links', [])
             observation_time = time.time()
-            log_message("Initial node {} connected links: {}".format(args.initial_node_id, links))
+            links_signature = tuple(sorted(str(link) for link in links))
+            if links_signature != last_initial_links_signature:
+                log_message("Initial node {} connected links: {}".format(args.initial_node_id, links))
+                last_initial_links_signature = links_signature
 
             update_disconnection_status(links, connection_state, observation_time)
 
@@ -455,7 +460,8 @@ def main():
                 node_id_str = str(node_id)
 
                 if is_whitelisted(node_id_str):
-                    log_message("Node {} is in the whitelist. It will remain connected.".format(node_id))
+                    if set_node_event(connection_state, node_id_str, 'whitelisted'):
+                        log_message("Node {} is in the whitelist. It will remain connected.".format(node_id))
                     continue
 
                 if handle_connection_attempt(node_id_str, connection_state, args.initial_node_id, observation_time):
@@ -497,7 +503,8 @@ def main():
 
                 # Explicitly check if the node is only connected to the initial node
                 if current_links == [args.initial_node_id]:
-                    log_message("Node {} is only connected to initial node {} and is not providing crosslink. It will remain connected.".format(node_id, args.initial_node_id))
+                    if set_node_event(connection_state, node_id_str, 'connected_to_initial_only'):
+                        log_message("Node {} is only connected to initial node {} and is not providing crosslink. It will remain connected.".format(node_id, args.initial_node_id))
                     continue
 
                 crosslink_detected, unexpected_nodes = detect_crosslinking(

--- a/nuke_nodes.py
+++ b/nuke_nodes.py
@@ -116,6 +116,17 @@ def load_whitelist(cli_whitelist_path):
         log_message("No whitelist file found in default locations. Proceeding without whitelist.")
     return set()
 
+def normalize_loop_interval(requested_interval):
+    """Return a safe loop interval; never abort in daemon mode because of a low value."""
+    if requested_interval is None:
+        return 60
+    if requested_interval < 10:
+        log_message(
+            "Loop interval {}s is below minimum. Using 10s to keep service running.".format(requested_interval)
+        )
+        return 10
+    return requested_interval
+
 
 def handle_connection_attempt(node_id, connection_state, initial_node_id, timestamp):
     """Handle repeated connect/disconnect behavior for a node."""
@@ -348,10 +359,7 @@ def main():
     if args.run_once:
         loop_interval = None
     else:
-        loop_interval = args.loop if args.loop is not None else 60
-        if loop_interval < 10:
-            print("Error: Loop interval must be at least 10 seconds.")
-            sys.exit(1)
+        loop_interval = normalize_loop_interval(args.loop)
 
     area_restrictions = load_list(args.area_restrictions) if args.area_restrictions else set()
     whitelist_entries = load_whitelist(args.whitelist)
@@ -368,117 +376,124 @@ def main():
             log_message("Node {} is whitelisted at startup. Removed from tracked state.".format(node_id))
 
     while True:
-        initial_data = fetch_data(initial_url)
+        try:
+            initial_data = fetch_data(initial_url)
 
-        if not initial_data:
-            if loop_interval is None:
-                log_message("No valid data retrieved for the initial node. Exiting after single pass.")
+            if not initial_data:
+                if loop_interval is None:
+                    log_message("No valid data retrieved for the initial node. Exiting after single pass.")
+                    save_state(connection_state)
+                    break
+
+                log_message("No valid data retrieved for the initial node. Waiting {} seconds before retrying.".format(loop_interval))
                 save_state(connection_state)
+                time.sleep(loop_interval)
+                continue
+
+            links = initial_data.get('stats', {}).get('data', {}).get('links', [])
+            observation_time = time.time()
+            log_message("Initial node {} connected links: {}".format(args.initial_node_id, links))
+
+            update_disconnection_status(links, connection_state, observation_time)
+
+            for node_id in links:
+                log_message("Processing node ID: {}".format(node_id))
+                node_id_str = str(node_id)
+
+                if is_whitelisted(node_id_str):
+                    log_message("Node {} is in the whitelist. It will remain connected.".format(node_id))
+                    continue
+
+                if handle_connection_attempt(node_id_str, connection_state, args.initial_node_id, observation_time):
+                    save_state(connection_state)
+                    continue
+
+                node_url = "https://stats.allstarlink.org/api/stats/" + str(node_id)
+                node_data = fetch_data(node_url)
+
+                if not node_data:
+                    log_message("No data available for node {}. Skipping to next node.".format(node_id))
+                    continue
+
+                # Check if stats field is None
+                stats = node_data.get("stats", None)
+                if stats is None:
+                    log_message("Node {} stats field is None. Treating as stats not enabled. Disconnecting and blocking.".format(node_id))
+                    reason = "Stat reporting disabled. Disconnecting and blocking node."
+                    update_blocked_node(node_id, reason)
+                    disconnect_node(node_id, args.initial_node_id, reason)
+                    connection_state.pop(node_id_str, None)
+                    log_message("Blocked and disconnected node {}. Continuing to next node.".format(node_id))
+                    save_state(connection_state)
+                    continue
+
+                # Check stats_enabled field
+                stats_enabled = node_data.get("stats_enabled", True)
+                log_message("Node {} stats_enabled value: {}".format(node_id, stats_enabled))
+
+                # Detect crosslinking
+                current_links = node_data.get('stats', {}).get('data', {}).get('links', [])
+                log_message("Node {} connected links: {}".format(node_id, current_links))
+
+                # Explicitly check if the node is only connected to the initial node
+                if current_links == [args.initial_node_id]:
+                    log_message("Node {} is only connected to initial node {} and is not providing crosslink. It will remain connected.".format(node_id, args.initial_node_id))
+                    continue
+
+                crosslink_detected, unexpected_nodes = detect_crosslinking(
+                    node_id, current_links, WHITELISTED_NODES, args.initial_node_id
+                )
+
+
+                if crosslink_detected:
+                    log_message("Crosslink detected on node {} with unexpected nodes: {}".format(node_id, unexpected_nodes))
+                    reason = "Crosslinking detected with unexpected nodes: {}".format(unexpected_nodes)
+                    update_blocked_node(node_id, reason)
+                    disconnect_node(node_id, args.initial_node_id, reason)
+                    connection_state.pop(node_id_str, None)
+                    log_message("Disconnected and blocked node {} due to crosslinking. Continuing to next node.".format(node_id))
+                    save_state(connection_state)
+                    continue
+
+                if stats_enabled is True:
+                    log_message("Node {} has stats explicitly enabled. It will remain connected.".format(node_id))
+                    continue
+
+                # Treat stats_enabled=None as disabled if stats is missing
+                if stats_enabled is None:
+                    log_message("Node {} stats_enabled is None. Treating as stats not enabled. Disconnecting and blocking.".format(node_id))
+                    reason = "Stat reporting disabled or missing. Disconnecting and blocking node."
+                    update_blocked_node(node_id, reason)
+                    disconnect_node(node_id, args.initial_node_id, reason)
+                    connection_state.pop(node_id_str, None)
+                    log_message("Blocked and disconnected node {}. Continuing to next node.".format(node_id))
+                    save_state(connection_state)
+                    continue
+
+                # Block and disconnect nodes explicitly reporting stats_enabled: False
+                if stats_enabled is False:
+                    log_message("Node {} stats_enabled is explicitly False. Disconnecting and blocking.".format(node_id))
+                    reason = "Stat reporting disabled. Disconnecting and blocking node."
+                    update_blocked_node(node_id, reason)
+                    disconnect_node(node_id, args.initial_node_id, reason)
+                    connection_state.pop(node_id_str, None)
+                    log_message("Blocked and disconnected node {}. Continuing to next node.".format(node_id))
+                    save_state(connection_state)
+                    continue
+
+            update_disconnection_status(links, connection_state, time.time())
+            save_state(connection_state)
+
+            if loop_interval is None:
                 break
 
-            log_message("No valid data retrieved for the initial node. Waiting {} seconds before retrying.".format(loop_interval))
-            save_state(connection_state)
             time.sleep(loop_interval)
-            continue
-
-        links = initial_data.get('stats', {}).get('data', {}).get('links', [])
-        observation_time = time.time()
-        log_message("Initial node {} connected links: {}".format(args.initial_node_id, links))
-
-        update_disconnection_status(links, connection_state, observation_time)
-
-        for node_id in links:
-            log_message("Processing node ID: {}".format(node_id))
-            node_id_str = str(node_id)
-
-            if is_whitelisted(node_id_str):
-                log_message("Node {} is in the whitelist. It will remain connected.".format(node_id))
-                continue
-
-            if handle_connection_attempt(node_id_str, connection_state, args.initial_node_id, observation_time):
-                save_state(connection_state)
-                continue
-
-            node_url = "https://stats.allstarlink.org/api/stats/" + str(node_id)
-            node_data = fetch_data(node_url)
-
-            if not node_data:
-                log_message("No data available for node {}. Skipping to next node.".format(node_id))
-                continue
-
-            # Check if stats field is None
-            stats = node_data.get("stats", None)
-            if stats is None:
-                log_message("Node {} stats field is None. Treating as stats not enabled. Disconnecting and blocking.".format(node_id))
-                reason = "Stat reporting disabled. Disconnecting and blocking node."
-                update_blocked_node(node_id, reason)
-                disconnect_node(node_id, args.initial_node_id, reason)
-                connection_state.pop(node_id_str, None)
-                log_message("Blocked and disconnected node {}. Continuing to next node.".format(node_id))
-                save_state(connection_state)
-                continue
-
-            # Check stats_enabled field
-            stats_enabled = node_data.get("stats_enabled", True)
-            log_message("Node {} stats_enabled value: {}".format(node_id, stats_enabled))
-
-            # Detect crosslinking
-            current_links = node_data.get('stats', {}).get('data', {}).get('links', [])
-            log_message("Node {} connected links: {}".format(node_id, current_links))
-
-            # Explicitly check if the node is only connected to the initial node
-            if current_links == [args.initial_node_id]:
-                log_message("Node {} is only connected to initial node {} and is not providing crosslink. It will remain connected.".format(node_id, args.initial_node_id))
-                continue
-
-            crosslink_detected, unexpected_nodes = detect_crosslinking(
-                node_id, current_links, WHITELISTED_NODES, args.initial_node_id
-            )
-
-
-            if crosslink_detected:
-                log_message("Crosslink detected on node {} with unexpected nodes: {}".format(node_id, unexpected_nodes))
-                reason = "Crosslinking detected with unexpected nodes: {}".format(unexpected_nodes)
-                update_blocked_node(node_id, reason)
-                disconnect_node(node_id, args.initial_node_id, reason)
-                connection_state.pop(node_id_str, None)
-                log_message("Disconnected and blocked node {} due to crosslinking. Continuing to next node.".format(node_id))
-                save_state(connection_state)
-                continue
-
-            if stats_enabled is True:
-                log_message("Node {} has stats explicitly enabled. It will remain connected.".format(node_id))
-                continue
-
-            # Treat stats_enabled=None as disabled if stats is missing
-            if stats_enabled is None:
-                log_message("Node {} stats_enabled is None. Treating as stats not enabled. Disconnecting and blocking.".format(node_id))
-                reason = "Stat reporting disabled or missing. Disconnecting and blocking node."
-                update_blocked_node(node_id, reason)
-                disconnect_node(node_id, args.initial_node_id, reason)
-                connection_state.pop(node_id_str, None)
-                log_message("Blocked and disconnected node {}. Continuing to next node.".format(node_id))
-                save_state(connection_state)
-                continue
-
-            # Block and disconnect nodes explicitly reporting stats_enabled: False
-            if stats_enabled is False:
-                log_message("Node {} stats_enabled is explicitly False. Disconnecting and blocking.".format(node_id))
-                reason = "Stat reporting disabled. Disconnecting and blocking node."
-                update_blocked_node(node_id, reason)
-                disconnect_node(node_id, args.initial_node_id, reason)
-                connection_state.pop(node_id_str, None)
-                log_message("Blocked and disconnected node {}. Continuing to next node.".format(node_id))
-                save_state(connection_state)
-                continue
-
-        update_disconnection_status(links, connection_state, time.time())
-        save_state(connection_state)
-
-        if loop_interval is None:
-            break
-
-        time.sleep(loop_interval)
+        except Exception as error:
+            log_message("Unexpected runtime error in main loop: {}".format(error))
+            save_state(connection_state)
+            if loop_interval is None:
+                raise
+            time.sleep(loop_interval)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
### Motivation
- Prevent nodes that were manually unblocked from remaining in a stale banned state and repeatedly logging "already banned" when they reconnect.
- Make ban state authoritative by checking the Asterisk database before treating a tracked node as still banned.

### Description
- Added a helper `is_node_blocked(node_id)` that queries the Asterisk DB via `asterisk -rx "database get blacklist <node>"` to determine if a node is actually blocked.
- Updated `handle_connection_attempt` to call `is_node_blocked` and clear the in-memory `banned` flag and reset attempt counters when the node has been unblocked externally. 
- Improved logging around stale-ban detection and state clearing to make the resolution visible in `nuke_nodes.log`.
- Changes made in `nuke_nodes.py` only.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976344447848328959bb070aed44b4c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-node fetch pacing with configurable delay and jitter and loop-interval normalization for safer daemon behavior.
  * Runtime visibility of node block/whitelist status and per-node event tracking to surface state changes.

* **Bug Fixes**
  * More robust handling of missing per-node data, compact 404 handling, and expanded retry/backoff for fetches.

* **Reliability**
  * Centralized per-node flow, improved cross-node processing, broader error handling, state persistence and logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->